### PR TITLE
Linux下编译，与SecureCRT接受文件时，传输数据会造成程序崩溃，调试发现是文件大小解析错误导致，现已修复

### DIFF
--- a/SerialPortYmodem/YmodemFileReceive.cpp
+++ b/SerialPortYmodem/YmodemFileReceive.cpp
@@ -1,4 +1,4 @@
-﻿#include "YmodemFileReceive.h"
+#include "YmodemFileReceive.h"
 
 #define READ_TIME_OUT   (10)
 #define WRITE_TIME_OUT  (100)
@@ -127,7 +127,9 @@ Ymodem::Code YmodemFileReceive::callback(Status status, uint8_t *buff, uint32_t 
                 }
 
                 fileName  = QString::fromLocal8Bit(name);
-                fileSize  = QString(size).toULongLong();
+                QString file_desc(size);
+                QString sizeStr = file_desc.left(file_desc.indexOf(' '));
+                fileSize  = sizeStr.toULongLong();
                 fileCount = 0;
 
                 file->setFileName(filePath + fileName);


### PR DESCRIPTION
# 测试环境
Linux 桌面环境，GCC编译器，使用SecureCRT

# 发现问题
1. 接受SecureCRT 发送的文件时， 程序崩溃退出

# 原因
1. SecureCRT 发送文件名后跟随文件大小，日期等信息，源代码将这些信息字符串转换为整型的结果为0
2. 在进行文件内容接受时会将这个文件大小作为分母进行运算，进而导致崩溃

# 解决方法
1. 由于文件长度等信息字符串之间由空格连接，因此，将文件长度信息从全部信息字符串中截取下来，并转换为整型，即可